### PR TITLE
Fixed issues and changed setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,14 @@ Access tokens expire after 1 hour kept by the Implicit Flow protocol. <br>
 The settings are separated into 2 main Django settings `JWT_CLIENT` for the `django_jwt` app and `JWT_SERVER` for the `django_jwt.server` app.
 
 ### OPENID2_URL [ JWT_CLIENT ]
-There is 3 types of configurations for this field:
-
-- **URL:** The openid service url without the `/.well-known/openid-configuration` path.
-- **Fake server:** In case of **development** and using jwt from the fake server you need to set this to `'fake'`.
-- **OpenId server:** If you want to deploy the openId app, you need to set to `'local'` in order to validate jwt tokens. Only for RestFramework.
+The openid service url without the `/.well-known/openid-configuration` path.
 
 ### CLIENT_ID [ JWT_CLIENT ]
 This is the client id of the openId service you are using. <br>
 If you want to validate the jwt from the OpenId server by `django_jwt.server` app you will need to add here the generated client_id on the admin page.
+
+### TYPE [ JWT_CLIENT ]
+This has 3 settings: `remote`, `local` and `fake` in order to use any of these types.
 
 ### RENAME_ATTRIBUTES [ JWT_CLIENT ]
 Dictionary to redirect the data and the `sub` attribute into the User attributes.
@@ -131,6 +130,7 @@ String that represents the identification of the cookie id of the JWT.
 JWT_CLIENT = {
     'OPENID2_URL': 'https://localhost:8000',    # Required
     'CLIENT_ID': 'client_id',                   # Required
+    'TYPE': 'remote',                           # Required
     'RENAME_ATTRIBUTES': {'sub': 'username'},   # Optional
     'DEFAULT_ATTRIBUTES': {},                   # Optional
     'CREATE_USER': True,                        # optional

--- a/django_jwt/apps.py
+++ b/django_jwt/apps.py
@@ -9,8 +9,8 @@ class DjangoJwtConfig(AppConfig):
     name = 'django_jwt'
 
     def ready(self):
-        url = get_setting('JWT_CLIENT.OPENID2_URL')
-        if url == 'local':
+        client_type = get_setting('JWT_CLIENT.CLIENT_TYPE')
+        if client_type == 'local':
             apps = get_setting('INSTALLED_APPS')
             if 'django_jwt.server' not in apps:
                 raise Exception('You need to add django_jwt.server into your INSTALLED_APPS in order to deploy the '
@@ -19,7 +19,7 @@ class DjangoJwtConfig(AppConfig):
                 reverse('oidc_config')
             except NoReverseMatch:
                 Exception('You need to include the django_jwt.urls into your app urls.py file')
-        if url == 'fake':
+        if client_type == 'fake':
             try:
                 reverse('fake_config')
             except NoReverseMatch:

--- a/django_jwt/rest_framework.py
+++ b/django_jwt/rest_framework.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import exceptions
 from rest_framework.authentication import TokenAuthentication
 from django.utils.translation import gettext_lazy as _
@@ -11,7 +13,9 @@ class JWTTokenAuthentication(TokenAuthentication):
     def authenticate_credentials(self, key):
         try:
             user = JWTAuthentication.authenticate_credentials(key)
-        except JWTAuthentication.JWTException:
+        except JWTAuthentication.JWTException as e:
+            logger = logging.getLogger(__name__)
+            logger.warning(e)
             raise exceptions.AuthenticationFailed(_('Token is invalid or expired.'))
         if not user:
             raise exceptions.AuthenticationFailed(_('User does not exist.'))

--- a/django_jwt/server/models.py
+++ b/django_jwt/server/models.py
@@ -36,6 +36,8 @@ class Key(models.Model):
         except cls.DoesNotExist:
             key = cls()
             key.save()
+        except cls.MultipleObjectsReturned:
+            key = cls.objects.filter(date__gt=(now - expiration_time)).order('-date').first()
         return key.to_jwk()
 
     @classmethod

--- a/django_jwt/settings_utils.py
+++ b/django_jwt/settings_utils.py
@@ -40,3 +40,7 @@ def get_setting(names):
     converter = JWT_DEFAULT_CONVERTERS.get(names, lambda x: x)
     value = converter(value)
     return value
+
+
+def get_domain_from_url(url):
+    return '/'.join(url.split('/')[0:3])

--- a/django_jwt/settings_utils.py
+++ b/django_jwt/settings_utils.py
@@ -16,6 +16,17 @@ JWT_DEFAULT_SETTINGS = {
 }
 
 
+def convert_url(url):
+    if len(url) > 0 and url[-1] == '/':
+        url = url[:-1]
+    return url
+
+
+JWT_DEFAULT_CONVERTERS = {
+    'JWT_CLIENT.OPENID2_URL': convert_url,
+}
+
+
 def get_setting(names):
     default = JWT_DEFAULT_SETTINGS.get(names, NoDefault)
     value = settings
@@ -26,4 +37,6 @@ def get_setting(names):
             value = getattr(value, name, default)
     if value == NoDefault:
         raise Exception('Setting %s is required' % names)
+    converter = JWT_DEFAULT_CONVERTERS.get(names, lambda x: x)
+    value = converter(value)
     return value

--- a/django_jwt/urls.py
+++ b/django_jwt/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path('logout', views.LogoutView.as_view(), name='oidc_logout'),
 ]
 
-if get_setting('JWT_CLIENT.OPENID2_URL') == 'fake':
+if get_setting('JWT_CLIENT.TYPE') == 'fake':
     urlpatterns.extend([
         path('jwks', views.jwks, name="fake_jwks"),
         path('fake-login', views.fake_login, name="fake_login"),

--- a/django_jwt/views.py
+++ b/django_jwt/views.py
@@ -26,10 +26,11 @@ class LoginView(View):
                 'response_type': get_setting('JWT_CLIENT.RESPONSE_TYPE')
             }
             return redirect(OpenId2Info().authorization_endpoint + '?' + urlencode(params))
-        if request.GET.get('state', None) != request.session['state']:
+        req_state = request.GET.get('state', None)
+        if req_state is not None and req_state != request.session.get('state', None):
             return HttpResponseBadRequest()
         try:
-            user = JWTAuthentication.authenticate_credentials(id_token, nonce=request.session['nonce'])
+            user = JWTAuthentication.authenticate_credentials(id_token, nonce=request.session.get('nonce', ''))
         except JWTAuthentication.JWTException:
             return HttpResponseBadRequest()
         if user is None:


### PR DESCRIPTION
- OPENID2_URL now must be a url (in order to verify JWT)
- New setting: JWT_CLIENT.TYPE (local, fake, remote) in order to set the type of the client.
- Fixed url now can have / on last char
- Added loggs into JWT verification
- Fixed issues with middleware session getter
- Fixed issues with getting more than one keys, now getting the more recent one
- Improved verification with the issuer