### PR TITLE
client_id argument added to function call in rest_framework.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ MIDDLEWARE = [
     ...
     'django.contrib.sessions.middleware.SessionMiddleware',
     ...
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django_jwt.middleware.JWTAuthenticationMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
     ...
 ]
 ```

--- a/django_jwt/rest_framework.py
+++ b/django_jwt/rest_framework.py
@@ -6,6 +6,7 @@ from rest_framework.authentication import TokenAuthentication
 from django.utils.translation import gettext_lazy as _
 
 from django_jwt.auth import JWTAuthentication
+from django_jwt.settings_utils import JWTAuthentication
 
 
 class JWTTokenAuthentication(TokenAuthentication):
@@ -13,7 +14,7 @@ class JWTTokenAuthentication(TokenAuthentication):
 
     def authenticate_credentials(self, key):
         try:
-            user, jwt = JWTAuthentication.authenticate_credentials(key)
+            user, jwt = JWTAuthentication.authenticate_credentials(key, client_id=get_setting('JWT_OIDC.CLIENT_ID'))
         except (JWTAuthentication.JWTException, JWTExpired) as e:
             logger = logging.getLogger(__name__)
             logger.warning(e)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = open(os.path.join(here, 'README.md')).read()
 
 setuptools.setup(
     name='django-jwt-oidc',
-    version=os.getenv('PACKAGE_VERSION').split('/')[-1],
+    version='1.0.11', # os.getenv('PACKAGE_VERSION').split('/')[-1],
     packages=setuptools.find_packages(),
     include_package_data=True,
     description='Django library that implements the authentification for OpenId SSO with JWT from oauth2.',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = open(os.path.join(here, 'README.md')).read()
 
 setuptools.setup(
     name='django-jwt-oidc',
-    version='1.0.11', # os.getenv('PACKAGE_VERSION').split('/')[-1],
+    version=os.getenv('PACKAGE_VERSION').split('/')[-1],
     packages=setuptools.find_packages(),
     include_package_data=True,
     description='Django library that implements the authentification for OpenId SSO with JWT from oauth2.',


### PR DESCRIPTION
The invocation of the `authenticate_credentials` method in `rest_framework.py` is done without the `client_id` argument. Since calling `authenticate_credentials` without specifying a `client_id` assigns it by default as `None`, this causes `verify_claims` to return `False` when `JWT_OIDC.TYPE` is 'provider'. As a result, `authenticate_credentials` then raises an exception. 