### PR TITLE
Added client_id argument to authenticate_credentials method call in rest_framework.py

### DIFF
--- a/django_jwt/rest_framework.py
+++ b/django_jwt/rest_framework.py
@@ -6,6 +6,7 @@ from rest_framework.authentication import TokenAuthentication
 from django.utils.translation import gettext_lazy as _
 
 from django_jwt.auth import JWTAuthentication
+from django_jwt.settings_utils import get_setting
 
 
 class JWTTokenAuthentication(TokenAuthentication):
@@ -13,7 +14,7 @@ class JWTTokenAuthentication(TokenAuthentication):
 
     def authenticate_credentials(self, key):
         try:
-            user, jwt = JWTAuthentication.authenticate_credentials(key)
+            user, jwt = JWTAuthentication.authenticate_credentials(key, client_id=get_setting('JWT_OIDC.CLIENT_ID'))
         except (JWTAuthentication.JWTException, JWTExpired) as e:
             logger = logging.getLogger(__name__)
             logger.warning(e)


### PR DESCRIPTION
The invocation of the `authenticate_credentials` method in `rest_framework.py` is done without the `client_id` argument. Since calling `authenticate_credentials` without specifying a `client_id` assigns it by default as `None`, this causes `verify_claims` to return `False` when `JWT_OIDC.TYPE` is 'provider'. As a result, `authenticate_credentials` then raises an exception. 

To fix this it is only necessary to add the argument `client_id` to `authenticate_credentials` and assign it the correct CLIENT_ID from JWT_OIDC.